### PR TITLE
Set up Go vanity URLs and add docs for Go lib

### DIFF
--- a/content/developers/go_c.md
+++ b/content/developers/go_c.md
@@ -1,0 +1,77 @@
++++
+title = "Go and C"
++++
+
+These two libraries are grouped together since they're based on the same code.
+
+- [Repository](github.com/UnifiedPush/go_dbus_connector)
+- [Go Documentation](//pkg.go.dev/unifiedpush.org/go/dbus_connector)
+
+An example app can be found in the \_examples folder of this module's repository.
+A link to the documentation of this module can be found [here](/go/dbus_connector).
+
+### C                                                                             
+                                                                                  
+The header files for the C library contains basic documentation, since it is only a wrapper around the Go lib that documentation will be very relevent. 
+ 
+It can be built from source using just the Go command (check Makefile). The releases contain statically linkable .a files and dynamically loadable .so files. 
+
+### Go
+
+An example import statement for the Go library is
+```go
+import (
+	up "unifiedpush.org/go/dbus_connector/api"
+	"unifiedpush.org/go/dbus_connector/definitions"
+)
+```
+
+### Usage
+
+1. The first thing the program should do on startup is checking if the app has been activated in the background for a notification. In this case, it should initialize the minimum resources that are required to process (or decrypt depending upon your app) the notification. This is communicated using an argument to the program.
+
+
+```go
+	up.InitializeAndCheck("cc.malhotra.karmanyaah.testapp.golibrary", handlerStruct)
+	// or
+	up.Initialize("cc.malhotra.karmanyaah.testapp.golibrary", handlerStruct)
+```
+running `up.Initialize` requires manually checking for the argument given on background activation, in case of `InitializeAndCheck` that argument is `UNIFIEDPUSH_DBUS_BACKGROUND_ACTIVATION`. The program should quit with an exit code of 0 after handling background notifications, which InitializeAndCheck does.
+
+The same applies to C except Initialize(AndCheck) takes in each function individually.
+```c
+	bool ok = UPInitializeAndCheck("cc.malhotra.karmanyaah.testapp.cgo", *newMessage, *newEndpoint, *unregistered);
+```
+
+2. If a distributor isn't already picked, the program should pick a distributor. If there are 0 distributors the program should stop using UnifiedPush; if there's 1, that should be auto-selected; and if there are more distributors, the user should be prompted to pick one.
+
+```go
+	if len(up.GetDistributor()) == 0 {
+		pickDist()
+	}
+```
+```c
+
+	if (strnlen(UPGetDistributor(), 1) == 0)
+		pickDistributors();
+```
+
+3. Every program should register each instance of notifications on startup, so that any updated endpoints can be sent.
+
+```go
+	result, reason, err := up.Register("")
+```
+```c
+	struct UPRegister_return ret = UPRegister("");
+	char *reason = ret.r1;
+	int status = ret.r0;
+```
+
+The reason is usually a user-readable error message.
+
+4. After this, your app can receive push notifications!
+    Some other methods are provided to unregister and/or change the UP config which are availible in the Godoc and every method there also has a C version.
+
+### Handler
+
+The notification handlers should not be dependent on any state to exist since they can be called at any time. Check the examples for how to use them.

--- a/content/developers/go_c.md
+++ b/content/developers/go_c.md
@@ -15,6 +15,10 @@ The header files for the C library contains basic documentation, since it is onl
 
 It can be built from source using just the Go command (check Makefile). The releases contain statically linkable .a files and dynamically loadable .so files.
 
+```c
+#include "libunifiedpush.h"
+```
+
 ### Go
 
 [Go Documentation](//pkg.go.dev/unifiedpush.org/go/dbus_connector)
@@ -51,7 +55,7 @@ else
 	return and the program continues like normal in the foreground
 ```
 
-In Go,
+**Go**
 
 ```go
 	up.InitializeAndCheck("cc.malhotra.karmanyaah.testapp.golibrary", handlerStruct)
@@ -59,7 +63,7 @@ In Go,
 	up.Initialize("cc.malhotra.karmanyaah.testapp.golibrary", handlerStruct)
 ```
 
-The same applies to C except Initialize(AndCheck) takes in each function individually.
+**C**
 
 ```c
 	bool ok = UPInitializeAndCheck("cc.malhotra.karmanyaah.testapp.cgo", *newMessage, *newEndpoint, *unregistered);
@@ -71,11 +75,15 @@ The same applies to C except Initialize(AndCheck) takes in each function individ
 
 If a distributor isn't already picked, the program should pick a distributor. If there are 0 distributors the program should stop using UnifiedPush; if there's 1, that should be auto-selected; and if there are more distributors, the user should be prompted to pick one.
 
+**Go**
+
 ```go
 	if len(up.GetDistributor()) == 0 {
 		pickDist()
 	}
 ```
+
+**C**
 
 ```c
 
@@ -87,9 +95,13 @@ If a distributor isn't already picked, the program should pick a distributor. If
 
 Every program should register each instance of notifications on startup, so that any updated endpoints can be sent.
 
+**Go**
+
 ```go
 	result, reason, err := up.Register("")
 ```
+
+**C**
 
 ```c
 	struct UPRegister_return ret = UPRegister("");
@@ -103,6 +115,8 @@ After this, your app can receive push notifications!
     Some other functions are provided to unregister and/or change the UP config which are available in the Godoc and every method there also has a C version.
 
 ### Handler
+
+#### C
 
 The notification handlers should not be dependent on any state to exist since they can be called at any time.
 
@@ -125,6 +139,10 @@ static void unregistered(char *instance)
 
 The functions above are passed into the initialization. In C, the function arguments are freed after the function returns so the data should be copied out if required. Each call gets an instance name which is the same as the one registered with.
 
+#### Go
+
+In Go, a struct is passed during initialization which must contain the following methods.
+
 ```go
 type NotificationHandler struct{}
 
@@ -141,8 +159,6 @@ func (n NotificationHandler) Unregistered(instance string) {
 	fmt.Println("endpoint unregistered")
 }
 ```
-
-In Go, a struct is passed during initialization which must contain the above methods.
 
 - NewMessage receives a string that can be deserialized into whatever format the server sends (json, etc).
 - NewEndpoint is called when a new endpoint needs to be saved or sent to the server.

--- a/content/developers/go_c.md
+++ b/content/developers/go_c.md
@@ -5,20 +5,22 @@ title = "Go and C"
 These two libraries are grouped together since they're based on the same code.
 
 - [Repository](github.com/UnifiedPush/go_dbus_connector)
-- [Go Documentation](//pkg.go.dev/unifiedpush.org/go/dbus_connector)
 
-An example app can be found in the \_examples folder of this module's repository.
+An example app can be found in the [\_examples folder](//github.com/UnifiedPush/go_dbus_connector/tree/main/_examples) of this module's repository.
 A link to the documentation of this module can be found [here](/go/dbus_connector).
 
-### C                                                                             
-                                                                                  
-The header files for the C library contains basic documentation, since it is only a wrapper around the Go lib that documentation will be very relevent. 
- 
-It can be built from source using just the Go command (check Makefile). The releases contain statically linkable .a files and dynamically loadable .so files. 
+### C
+
+The header files for the C library contains basic documentation, since it is only a wrapper around the Go lib the godoc will be very relevant.
+
+It can be built from source using just the Go command (check Makefile). The releases contain statically linkable .a files and dynamically loadable .so files.
 
 ### Go
 
+[Go Documentation](//pkg.go.dev/unifiedpush.org/go/dbus_connector)
+
 An example import statement for the Go library is
+
 ```go
 import (
 	up "unifiedpush.org/go/dbus_connector/api"
@@ -26,41 +28,69 @@ import (
 )
 ```
 
+```bash
+go get -u unifiedpush.org/go/dbus_connector
+```
+
 ### Usage
 
-1. The first thing the program should do on startup is checking if the app has been activated in the background for a notification. In this case, it should initialize the minimum resources that are required to process (or decrypt depending upon your app) the notification. This is communicated using an argument to the program.
+#### Initialization
 
+On startup the program should check if it was awaken for push first. If so, it should initialize as little as required to notify the user. The background status is in an argument.
+
+Running `up.Initialize` requires manually checking for the argument. `UNIFIEDPUSH_DBUS_BACKGROUND_ACTIVATION` is the recommended argument to be used in the DBus service file.  
+
+In pseudocode, the function `up.InitializeAndCheck` does the following
+
+```
+up.Initialize(whatever arguments are required)
+if (program is in background) //UNIFIEDPUSH_DBUS_BACKGROUND_ACTIVATION is given
+	Call background handlers
+	once the handlers return, exit
+else
+	return and the program continues like normal in the foreground
+```
+
+In Go,
 
 ```go
 	up.InitializeAndCheck("cc.malhotra.karmanyaah.testapp.golibrary", handlerStruct)
 	// or
 	up.Initialize("cc.malhotra.karmanyaah.testapp.golibrary", handlerStruct)
 ```
-running `up.Initialize` requires manually checking for the argument given on background activation, in case of `InitializeAndCheck` that argument is `UNIFIEDPUSH_DBUS_BACKGROUND_ACTIVATION`. The program should quit with an exit code of 0 after handling background notifications, which InitializeAndCheck does.
 
 The same applies to C except Initialize(AndCheck) takes in each function individually.
+
 ```c
 	bool ok = UPInitializeAndCheck("cc.malhotra.karmanyaah.testapp.cgo", *newMessage, *newEndpoint, *unregistered);
+	// or
+	bool ok = UPInitialize("cc.malhotra.karmanyaah.testapp.cgo", *newMessage, *newEndpoint, *unregistered);
 ```
 
-2. If a distributor isn't already picked, the program should pick a distributor. If there are 0 distributors the program should stop using UnifiedPush; if there's 1, that should be auto-selected; and if there are more distributors, the user should be prompted to pick one.
+#### Distributor Selection
+
+If a distributor isn't already picked, the program should pick a distributor. If there are 0 distributors the program should stop using UnifiedPush; if there's 1, that should be auto-selected; and if there are more distributors, the user should be prompted to pick one.
 
 ```go
 	if len(up.GetDistributor()) == 0 {
 		pickDist()
 	}
 ```
+
 ```c
 
 	if (strnlen(UPGetDistributor(), 1) == 0)
 		pickDistributors();
 ```
 
-3. Every program should register each instance of notifications on startup, so that any updated endpoints can be sent.
+#### (Re)Registration
+
+Every program should register each instance of notifications on startup, so that any updated endpoints can be sent.
 
 ```go
 	result, reason, err := up.Register("")
 ```
+
 ```c
 	struct UPRegister_return ret = UPRegister("");
 	char *reason = ret.r1;
@@ -69,9 +99,51 @@ The same applies to C except Initialize(AndCheck) takes in each function individ
 
 The reason is usually a user-readable error message.
 
-4. After this, your app can receive push notifications!
-    Some other methods are provided to unregister and/or change the UP config which are availible in the Godoc and every method there also has a C version.
+After this, your app can receive push notifications!
+    Some other functions are provided to unregister and/or change the UP config which are available in the Godoc and every method there also has a C version.
 
 ### Handler
 
-The notification handlers should not be dependent on any state to exist since they can be called at any time. Check the examples for how to use them.
+The notification handlers should not be dependent on any state to exist since they can be called at any time.
+
+```c
+static void newMessage(char *instance, char *msg, char *id)
+{
+	printf("new message: %s\n", msg);
+}
+
+static void newEndpoint(char *instance, char *endpoint)
+{
+	printf("new endpoint received: %s\n", endpoint);
+}
+
+static void unregistered(char *instance)
+{
+	printf("instance unregistered\n");
+}
+```
+
+The functions above are passed into the initialization. In C, the function arguments are freed after the function returns so the data should be copied out if required. Each call gets an instance name which is the same as the one registered with.
+
+```go
+type NotificationHandler struct{}
+
+func (n NotificationHandler) Message(instance, message, id string) {
+	fmt.Println("new message received")
+	_ := beeep.Notify("title", message, "")
+}
+
+func (n NotificationHandler) NewEndpoint(instance, endpoint string) {
+	fmt.Println("New endpoint received", endpoint)
+}
+
+func (n NotificationHandler) Unregistered(instance string) {
+	fmt.Println("endpoint unregistered")
+}
+```
+
+In Go, a struct is passed during initialization which must contain the above methods.
+
+- NewMessage receives a string that can be deserialized into whatever format the server sends (json, etc).
+- NewEndpoint is called when a new endpoint needs to be saved or sent to the server.
+- Unregister is called when the distributor has unregistered the app either due to request or something on the distributor side.

--- a/content/developers/go_c.md
+++ b/content/developers/go_c.md
@@ -183,3 +183,14 @@ func (n NotificationHandler) Unregistered(instance string) {
 - NewMessage receives a string that can be deserialized into whatever format the server sends (json, etc).
 - NewEndpoint is called when a new endpoint needs to be saved or sent to the server.
 - Unregister is called when the distributor has unregistered the app either due to request or something on the distributor side.
+
+## Background activation
+
+A D-Bus service file needs to be packaged with your application and placed in the D-Bus activation directory to let it activate for a background notification. The name here is the same argument passed to initialize; Exec is the binary being executed with the activation argument.
+
+This directory is usually `share/dbus-1/services/` in `~/.local` or `/usr`
+```service
+[D-BUS Service]
+Name=cc.malhotra.karmanyaah.testapp.cgo
+Exec=<path to binary>/appBinaryname UNIFIEDPUSH_DBUS_BACKGROUND_ACTIVATION
+```

--- a/content/developers/go_c.md
+++ b/content/developers/go_c.md
@@ -68,12 +68,13 @@ else
     {{< tab "C" >}}
 
 ```c
-bool ok = UPInitializeAndCheck("org.yourapp.domain", *newMessage, *newEndpoint, *unregistered);
+bool ok = UPInitializeAndCheck("org.example.app", *newMessage, *newEndpoint, *unregistered);
 // or
-bool ok = UPInitialize("org.yourapp.domain", *newMessage, *newEndpoint, *unregistered);
-if (containsString("UNIFIEDPUSH_DBUS_BACKGROUND_ACTIVATION", argv)) { //containsString needs to be a function
+bool ok = UPInitialize("org.example.app", *newMessage, *newEndpoint, *unregistered);
+if (containsString("UNIFIEDPUSH_DBUS_BACKGROUND_ACTIVATION", argv)) { // containsString needs to be defined
+    // your code here, for instance:
     sleep(5);
-    // this gives time for the functions to be called
+    // this gives the callback functions some time to run
     exit(0);
 }
 ```
@@ -82,11 +83,13 @@ if (containsString("UNIFIEDPUSH_DBUS_BACKGROUND_ACTIVATION", argv)) { //contains
     {{< tab "Go" >}} 
 
 ```go
-up.InitializeAndCheck("xyz.yourdomain.yourapp", handlerStruct)
+up.InitializeAndCheck("org.example.app", handlerStruct)
 // or
-up.Initialize("net.yourorganization.yourproduct.yourappname", handlerStruct)
-if containsString(os.Args, "UNIFIEDPUSH_DBUS_BACKGROUND_ACTIVATION") {// containsString needs to be defined
-    time.Sleep(5 * time.Second) // this gives the callback functions some time to run
+up.Initialize("org.example.app", handlerStruct)
+if containsString(os.Args, "UNIFIEDPUSH_DBUS_BACKGROUND_ACTIVATION") { // containsString needs to be defined
+    // your code here, for instance:
+    time.Sleep(5 * time.Second) 
+    // this gives the callback functions some time to run
     os.Exit(0)
 }
 ```
@@ -204,6 +207,6 @@ This directory is usually `share/dbus-1/services/` in `~/.local` or `/usr`
 
 ```service
 [D-BUS Service]
-Name=cc.malhotra.karmanyaah.testapp.cgo
+Name=org.example.app
 Exec=<path to binary>/appBinaryname UNIFIEDPUSH_DBUS_BACKGROUND_ACTIVATION
 ```

--- a/content/go/_index.md
+++ b/content/go/_index.md
@@ -1,0 +1,3 @@
++++
+geekdocHidden = true
++++

--- a/content/go/_index.md
+++ b/content/go/_index.md
@@ -1,3 +1,5 @@
 +++
 geekdocHidden = true
 +++
+
+{{<toc-tree>}}

--- a/content/go/dbus_connector.md
+++ b/content/go/dbus_connector.md
@@ -9,3 +9,4 @@ aliases = [
     "dbus_connector/definitions",
 ]
 +++
+random thing that won't be rendered but is needed for toc on /go/ path

--- a/content/go/dbus_connector.md
+++ b/content/go/dbus_connector.md
@@ -1,0 +1,11 @@
++++
+vanity = "github.com/UnifiedPush/go_dbus_connector"
+root = "unifiedpush.org"
+
+# aliases for user convinience, not mandatory for things to work
+aliases = [
+    "dbus_connector/api",
+    "dbus_connector/api_c",
+    "dbus_connector/definitions",
+]
++++

--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html><html>
+    <head>
+        {{if .Page.Params.vanity -}}
+          <meta name="go-import" content="{{.Params.root}}{{substr .RelPermalink 0 -1}} git {{.Params.vanity}}">
+  <meta name="go-source" content="{{.Params.root}}{{substr .RelPermalink 0 -1}} https://{{.Params.vanity}} https://{{.Params.vanity}}/tree/main{/dir} https://{{.Params.vanity}}/blob/main{/dir}/{file}#L{line}">
+        {{- end}}
+        <title>{{ .Permalink }}</title>
+        <link rel="canonical" href="{{ .Permalink }}"/>
+        <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+        <meta http-equiv="refresh" content="0; url={{ .Permalink }}" />
+    </head>
+    <body>
+	    <a href="{{ .Permalink }}"> Redirecting ... </a>
+    </body>
+</html>

--- a/layouts/go/single.html
+++ b/layouts/go/single.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8">
+  <meta name="go-import" content="{{.Params.root}}{{substr .RelPermalink 0 -1}} git {{.Params.vanity}}">
+  <meta name="go-source" content="{{.Params.root}}{{substr .RelPermalink 0 -1}} https://{{.Params.vanity}} https://{{.Params.vanity}}/tree/main{/dir} https://{{.Params.vanity}}/blob/main{/dir}/{file}#L{line}">
+</head>
+<body>
+	<ol>
+		<li>Find more info at <a href="//{{.Params.vanity}}">{{.Params.vanity}}</a></li>
+		<li>Find docs at <a href="//pkg.go.dev/{{.Params.vanity}}">pkg.go.dev</a></li>
+	</ol>
+</body>
+</html>


### PR DESCRIPTION
This allows the dbus connector and any future UnifiedPush Go modules to be resolved as

```go
import "unifiedpush.org/go/dbus_connector"
```
instead of 
```go
import "github.com/unifiedpush/go_dbus_connector
```
and allows for more future flexibility.
