### PR TITLE
Reduce TTL in deployment to speed up IPFS deploys

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,4 +48,4 @@ jobs:
           remove-old: true
         id: deploy
       - name: DNSLINK
-        run: 'curl -D- -X PUT -H "Content-Type: application/json" -H "Authorization: Apikey ${{ secrets.GandiAPI }}" -d "{\"rrset_ttl\": 1800,\"rrset_values\": [\"dnslink=/ipfs/${{ steps.deploy.outputs.HASH }}\"]}" https://api.gandi.net/v5/livedns/domains/unifiedpush.org/records/_dnslink/TXT'
+        run: 'curl -D- -X PUT -H "Content-Type: application/json" -H "Authorization: Apikey ${{ secrets.GandiAPI }}" -d "{\"rrset_ttl\": 300,\"rrset_values\": [\"dnslink=/ipfs/${{ steps.deploy.outputs.HASH }}\"]}" https://api.gandi.net/v5/livedns/domains/unifiedpush.org/records/_dnslink/TXT'


### PR DESCRIPTION
This is the minimum value that gandi.net allows.
idk if you want to do this for various reasons but i'm just suggesting.