### PR TITLE
Fix link to gotify page

### DIFF
--- a/content/users/distributors/_index.md
+++ b/content/users/distributors/_index.md
@@ -10,7 +10,7 @@ title: Distributors
 
 Gotify works with a server.
 
-Right now Gotify is UnifiedPush's primary distributor. There are public servers and more information available on the [Gotify page](./gotify.md)
+Right now Gotify is UnifiedPush's primary distributor. There are public servers and more information available on the [Gotify page](./gotify)
 
 ### UP-FCM Distributor
 


### PR DESCRIPTION
The current link points to https://unifiedpush.org/users/distributors/gotify.md but it should be https://unifiedpush.org/users/distributors/gotify