### PR TITLE
Update embedded_fcm.md

### DIFF
--- a/content/developers/embedded_fcm.md
+++ b/content/developers/embedded_fcm.md
@@ -31,11 +31,16 @@ You will need to add some code on your android project and host a FCM Rewrite pr
 * Add the receiver to your code:
 
 ```kotlin
+package YOUR.PACKAGE.ID
+
+import android.content.Context
+import org.unifiedpush.android.foss_embedded_fcm_distributor.EmbeddedDistributorReceiver
+
 class EmbeddedDistributor: EmbeddedDistributorReceiver() {
 
     override val googleProjectNumber = "123456" // This value comes from the google-services.json
 
-    override fun getEndpoint(context: Context, fcmToken: String, instance: String): String {
+    override fun getEndpoint(context: Context, token: String, instance: String): String {
         // This returns the endpoint of your FCM Rewrite-Proxy
         return "https://<your.domain.tld>/FCM?v2&instance=$instance&token=$token"
     }


### PR DESCRIPTION
In the Kotlin example the imports were missing. For Flutter developers it is very handy to also show this so they don't need to open Android Studio to resolve them. Also the parameter `token` was named `fcmToken` which was not working when copy pasting the example code.