### PR TITLE
Fix page edit links on the website

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -48,7 +48,7 @@ enableRobotsTXT = true
   # (Optional, default none) Enable 'Edit this page' links. Requires 'GeekdocRepo' param
   # and path must point to 'content' directory of repo.
   # You can also specify this parameter per page in front matter.
-  geekdocEditPath = "edit/main/content"
+  geekdocEditPath = "blob/main"
 
   # (Optional, default true) Enables search function with flexsearch.
   # Index is built on the fly and might slowdown your website.


### PR DESCRIPTION
Clicking on "edit this page" on the website would land the user on a github 404. I think this fixes it.