### PR TITLE
add distributor Conversations

### DIFF
--- a/content/users/distributors/_index.md
+++ b/content/users/distributors/_index.md
@@ -21,6 +21,7 @@ UnifiedPush allows you to choose between multiple implementations and servers, b
 
 * [ntfy](/users/distributors/ntfy): You just need to install it.
 * [UP-FCM Distributor](/users/distributors/fcm): The same as above. Just be aware that it uses Google servers.
+* [Conversations](/users/distributors/conversations): Conversations is an instant messaging client for Android which can also act as a UnifiedPush distributor.
 
 ### Self-host the server (Difficult)
 
@@ -33,6 +34,11 @@ The ntfy server can be easily be self-hosted. It can be installed with a package
 #### [NextPush](/users/distributors/nextpush)
 
 NextPush is a push server that can be hosted as a Nextcloud app. This is an easy way to self-host a push server if you already have a Nextcloud server.
+
+#### [Conversations](/users/distributors/conversations)
+
+Conversations uses the push server `up.conversations.im` per default, but this can be changed in the settings.
+There is [a component](https://codeberg.org/iNPUTmice/up) which allows any XMPP server to act as push server for Conversations.
 
 ### Other options
 

--- a/content/users/distributors/conversations.md
+++ b/content/users/distributors/conversations.md
@@ -1,0 +1,23 @@
+---
+geekdocHidden: true
+geekdocHiddenTocTree: false
+title: Conversations
+weight: 20
+---
+
+Conversations is a Jabber/XMPP client for Android 5.0+ smartphones which can also act as a UnifiedPush distributor.
+You can enable this functionality in the settings by choosing which XMPP account should be used to receive push messages.
+
+* License: GPLv3
+* Sources: <https://codeberg.org/iNPUTmice/Conversations>
+* Server: `up.conversations.im` or your your own XMPP server
+* Technology: XMPP
+* Download for Android:
+
+[<img alt="Get it on F-Droid" src="/img/f-droid-badge.png" height=100>](https://f-droid.org/en/packages/eu.siacs.conversations/)
+
+## Server Requirements
+
+* Per default, Conversations uses the push server at `up.conversations.im`.
+* If you host your own XMPP chat server, it can act as a push server for Conversations by connecting [this component](https://codeberg.org/iNPUTmice/up) to it.
+* Prosody can act as a push server by enabling [`mod_unified_push`](https://modules.prosody.im/mod_unified_push.html) community module.


### PR DESCRIPTION
Conversations can now act as a UnifiedPush distributor. See [changelog](https://codeberg.org/iNPUTmice/Conversations/commit/4670f643f3b086524d6cb282b1179597088c426e).